### PR TITLE
Fix compile error ('transform' is not a member of 'std')

### DIFF
--- a/src/pch.h
+++ b/src/pch.h
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <ctime>
+#include <algorithm>
 
 #ifdef DEBUG
     #include "Core/Log.h"


### PR DESCRIPTION
I ran into an error during compilation (Debian Sid, GCC 14.2) where the compiler could not make sense of the "transform" function. Adding the algorithm header fixes this.